### PR TITLE
Fix queue allocations

### DIFF
--- a/geoindex.go
+++ b/geoindex.go
@@ -141,49 +141,44 @@ type qnode struct {
 	child child.Child
 }
 
-type queue struct {
-	nodes []qnode
-	len   int
-	size  int
-}
+type queue []qnode
 
 func (q *queue) push(node qnode) {
-	if q.nodes == nil {
-		q.nodes = make([]qnode, 2)
-	} else {
-		q.nodes = append(q.nodes, qnode{})
+	*q = append(*q, node)
+	nodes := *q
+	i := len(nodes) - 1
+	for parent := (i - 1) / 2; i != 0 && nodes[parent].dist > nodes[i].dist; parent = (i - 1) / 2 {
+		nodes[parent], nodes[i] = nodes[i], nodes[parent]
+		i = parent
 	}
-	i := q.len + 1
-	j := i / 2
-	for i > 1 && q.nodes[j].dist > node.dist {
-		q.nodes[i] = q.nodes[j]
-		i = j
-		j = j / 2
-	}
-	q.nodes[i] = node
-	q.len++
 }
 
 func (q *queue) pop() (qnode, bool) {
-	if q.len == 0 {
+	nodes := *q
+	if len(nodes) == 0 {
 		return qnode{}, false
 	}
-	n := q.nodes[1]
-	q.nodes[1] = q.nodes[q.len]
-	q.len--
-	var j, k int
-	i := 1
-	for i != q.len+1 {
-		k = q.len + 1
-		j = 2 * i
-		if j <= q.len && q.nodes[j].dist < q.nodes[k].dist {
-			k = j
+	var n qnode
+	n, nodes[0] = nodes[0], nodes[len(*q)-1]
+	nodes = nodes[:len(nodes)-1]
+	*q = nodes
+
+	i := 0
+	for {
+		smallest := i
+		left := i*2 + 1
+		right := i*2 + 2
+		if left < len(nodes) && nodes[left].dist <= nodes[smallest].dist {
+			smallest = left
 		}
-		if j+1 <= q.len && q.nodes[j+1].dist < q.nodes[k].dist {
-			k = j + 1
+		if right < len(nodes) && nodes[right].dist <= nodes[smallest].dist {
+			smallest = right
 		}
-		q.nodes[i] = q.nodes[k]
-		i = k
+		if smallest == i {
+			break
+		}
+		nodes[smallest], nodes[i] = nodes[i], nodes[smallest]
+		i = smallest
 	}
 	return n, true
 }

--- a/geoindex_test.go
+++ b/geoindex_test.go
@@ -35,3 +35,82 @@ func TestGeoIndex(t *testing.T) {
 func BenchmarkRandomInsert(b *testing.B) {
 	Tests.BenchmarkRandomInsert(b, &rbang.RTree{})
 }
+
+func TestQueue(t *testing.T) {
+	var q queue
+
+	q.push(qnode{
+		dist: 2,
+	})
+	q.push(qnode{
+		dist: 1,
+	})
+	q.push(qnode{
+		dist: 5,
+	})
+	q.push(qnode{
+		dist: 3,
+	})
+	q.push(qnode{
+		dist: 4,
+	})
+
+	lastDist := float64(-1)
+	for i := 0; i < 3; i++ {
+		node, ok := q.pop()
+		if !ok {
+			t.Fatal("queue was empty")
+		}
+		if node.dist < lastDist {
+			t.Fatal("queue was out of order")
+		}
+	}
+
+	if len(q) != 2 {
+		t.Fatal("queue was wrong size")
+	}
+
+	capBeforeInserts := cap(q)
+	q.push(qnode{
+		dist: 1,
+	})
+	q.push(qnode{
+		dist: 10,
+	})
+	q.push(qnode{
+		dist: 11,
+	})
+
+	if cap(q) != capBeforeInserts {
+		t.Fatal("queue did not reuse space")
+	}
+
+	lastDist = -1
+	for i := 0; i < 5; i++ {
+		node, ok := q.pop()
+		if !ok {
+			t.Fatal("queue was empty")
+		}
+		if node.dist < lastDist {
+			t.Fatal("queue was out of order")
+		}
+	}
+
+	_, ok := q.pop()
+	if ok {
+		t.Fatal("queue was not empty")
+	}
+}
+
+func BenchmarkQueue(b *testing.B) {
+	var q queue
+
+	for i := 0; i < b.N; i++ {
+		r := rand.Float64()
+		if r < 0.5 {
+			q.push(qnode{dist: r})
+		} else {
+			q.pop()
+		}
+	}
+}


### PR DESCRIPTION
The current implementation of queue allocates a memory slot via `append` with every call to `push`, even if there is free capacity in the node slice. This causes far too many allocations in the kNN algorithm since the memory use of the queue is proportional to the number of items examined at any point in the algorithm, not the number of active items competing in the queue.

The bug was masked by treating the nodes slice and the length of the queue independently. This implementation rewrites the queue to a slightly more idiomatic implementation that relies on a slice and uses the length of the slice instead of a separate length field to avoid future problems of this sort.